### PR TITLE
[Feature] Allow to use function defined in a Fetcher

### DIFF
--- a/vm/runtime.go
+++ b/vm/runtime.go
@@ -132,6 +132,19 @@ func FetchFn(from interface{}, name string) reflect.Value {
 			return value
 		}
 	}
+
+	if fetcher, ok := from.(Fetcher); ok {
+		if value := fetcher.Fetch(name); value != nil {
+			fn := reflect.ValueOf(value)
+			if fn.Kind() == reflect.Ptr {
+				fn = fn.Elem()
+			}
+			if fn.IsValid() {
+				return fn
+			}
+		}
+	}
+
 	panic(fmt.Sprintf(`cannot get "%v" from %T`, name, from))
 }
 


### PR DESCRIPTION
Today the `fetcher.Fetch` is ignored for function calls, making it impossible to create functions at runtime.

This PR adds this feature, allowing the build below to take place.


```golang
type FetcherMap struct {
	data map[string]interface{}
}

func (m *FetcherMap) Set(key string, value interface{}) {
	if m.data == nil {
		m.data = map[string]interface{}{}
	}
	m.data[key] = value
}

func (m *FetcherMap) Fetch(key interface{}) interface{} {
	if keyStr, ok := key.(string); ok {
		if value, exists := m.data[keyStr]; exists {
			return value
		}
	}
	return nil
}

func TestRun_fetch_functions(t *testing.T) {
	input := `hello() + world() + suffix()`

	tree, err := parser.Parse(input)
	require.NoError(t, err)

	program, err := compiler.Compile(tree, nil)
	require.NoError(t, err)

	fetcher := &FetcherMap{}
	fetcher.Set("hello", func() string { return "hello " })
	fetcher.Set("world", func() string { return "world" })
	suffixFnPtr := func() string { return "!" }
	fetcher.Set("suffix", &suffixFnPtr)

	out, err := vm.Run(program, fetcher)
	require.NoError(t, err)

	require.Equal(t, "hello world!", out)
}
```

fix https://github.com/antonmedv/expr/issues/247

![image](https://user-images.githubusercontent.com/675430/188250217-3d6cf8eb-4430-4957-8bf0-8f45ac52df6a.png)
